### PR TITLE
Fix trace logging being left enabled in committed code

### DIFF
--- a/markdown/src/main/java/guideme/libs/micromark/Micromark.java
+++ b/markdown/src/main/java/guideme/libs/micromark/Micromark.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public final class Micromark {
 
-    public static final boolean ENABLE_TRACE = true;
+    public static final boolean ENABLE_TRACE = false;
 
     private Micromark() {
     }


### PR DESCRIPTION
Trace logging here is very expensive and accounts for most of the resource reload time spent loading GuideME guidebooks. This appears to have been turned on by accident in https://github.com/AppliedEnergistics/GuideME/commit/645328571c55237445d0fb404a3b65a00622924e.