### PR TITLE
chore: Update directory watcher and tell ProGuard to leave it alone

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ neoforge_version_range=[26.1.2.10-beta,26.2-)
 # Third party dependencies
 #########################################################
 snakeyaml_version=1.33
-directory_watcher_version=0.17.1
+directory_watcher_version=0.19.1
 junit_version=5.13.4
 flatbuffers_version=23.5.26
 ffmpeg_version=6.0-1.5.9

--- a/proguard.conf
+++ b/proguard.conf
@@ -26,6 +26,7 @@
     *;
 }
 
--keep class guideme.internal.shaded.methvin.** {
+# Ensure all JNI classes for DirectoryWatcher are kept to ensure hot reload works on MacOS
+-keep class guideme.internal.shaded.methvin.watchservice.jna.* {
     *;
 }

--- a/proguard.conf
+++ b/proguard.conf
@@ -25,3 +25,7 @@
 -keepclassmembers class guideme.internal.hooks.mixins.* {
     *;
 }
+
+-keep class guideme.internal.shaded.methvin.** {
+    *;
+}


### PR DESCRIPTION
Fixes MacOS directory watcher by ensuring ProGuard doesn't strip constructors used by JNI.

Also bumps the version of directory watcher as it also has MacOS JNI improvements.