### PR TITLE
Add option to hide slot in LytSlot

### DIFF
--- a/src/main/java/guideme/document/block/LytSlot.java
+++ b/src/main/java/guideme/document/block/LytSlot.java
@@ -31,6 +31,7 @@ public class LytSlot extends LytBlock implements InteractiveElement {
     private static final int CYCLE_TIME = 2000;
 
     private boolean largeSlot;
+    private boolean visibleSlot = true;
 
     private final List<ItemStack> stacks;
 
@@ -62,6 +63,10 @@ public class LytSlot extends LytBlock implements InteractiveElement {
         this.largeSlot = largeSlot;
     }
 
+    public boolean isSlotVisible() {return visibleSlot;}
+
+    public void setSlotVisible(boolean visibleSlot){this.visibleSlot = visibleSlot;}
+
     @Override
     protected LytRect computeLayout(LayoutContext context, int x, int y, int availableWidth) {
         if (largeSlot) {
@@ -80,19 +85,20 @@ public class LytSlot extends LytBlock implements InteractiveElement {
         var x = bounds.x();
         var y = bounds.y();
 
-        GuiSprite texture;
-        if (largeSlot) {
-            texture = GuiAssets.LARGE_SLOT;
-        } else {
-            texture = GuiAssets.SLOT;
+        if (visibleSlot) {
+            GuiSprite texture;
+            if (largeSlot) {
+                texture = GuiAssets.LARGE_SLOT;
+            } else {
+                texture = GuiAssets.SLOT;
+            }
+            context.fillIcon(bounds, texture);
         }
-        context.fillIcon(bounds, texture);
-
         var padding = largeSlot ? LARGE_PADDING : PADDING;
 
         var stack = getDisplayedStack();
         if (!stack.isEmpty()) {
-            context.renderItem(stack, x + padding, y + padding, 1, ITEM_SIZE, ITEM_SIZE);
+            context.renderItem(stack, x + padding, y + padding, visibleSlot? 1: 0, ITEM_SIZE, ITEM_SIZE);
         }
     }
 


### PR DESCRIPTION

added `isSlotVisible` and `setSlotVisible` to hide the slot in LytSLot. Should be trivial to backport.

|Visible (default)|Invisible|
|---|---|
|<img width="184" height="150" alt="image" src="https://github.com/user-attachments/assets/c1fbfae9-8a5f-4539-9ec8-1db5e8c270f8" />|<img width="184" height="150" alt="image" src="https://github.com/user-attachments/assets/6a384cd1-3b07-44f4-92e1-cc0080f506bc" />|