### PR TITLE
Refactor GFM table header state handling

### DIFF
--- a/markdown/src/main/java/guideme/libs/micromark/extensions/gfm/GfmTableSyntax.java
+++ b/markdown/src/main/java/guideme/libs/micromark/extensions/gfm/GfmTableSyntax.java
@@ -15,6 +15,8 @@ import guideme.libs.micromark.Types;
 import guideme.libs.micromark.factory.FactorySpace;
 import guideme.libs.micromark.symbol.Codes;
 import guideme.libs.micromark.symbol.Constants;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -59,9 +61,9 @@ public class GfmTableSyntax extends Extension {
                 }
 
                 if (
-                // Combine separate content parts into one.
-                (token.type.equals("tableCellDivider") || token.type.equals("tableRow")) &&
-                        contentEnd != -1) {
+                    // Combine separate content parts into one.
+                        (token.type.equals("tableCellDivider") || token.type.equals("tableRow")) &&
+                                contentEnd != -1) {
                     Assert.check(
                             contentStart != -1,
                             "expected `contentStart` to be defined if `contentEnd` is");
@@ -249,6 +251,10 @@ public class GfmTableSyntax extends Extension {
                 }
 
                 Assert.check(CharUtil.markdownLineEnding(code), "expected eol");
+                return getState(code);
+            }
+
+            private @Nullable State getState(int code) {
                 effects.exit("tableRow");
                 effects.exit("tableHead");
                 var originalInterrupt = context.isInterrupt();
@@ -395,12 +401,12 @@ public class GfmTableSyntax extends Extension {
                 construct.partial = true;
 
                 return effects.check.hook(
-                        nextPrefixedOrBlank,
-                        this::tableClose,
-                        effects.attempt.hook(
-                                construct,
-                                FactorySpace.create(effects, this::bodyStart, Types.linePrefix, Constants.tabSize),
-                                this::tableClose))
+                                nextPrefixedOrBlank,
+                                this::tableClose,
+                                effects.attempt.hook(
+                                        construct,
+                                        FactorySpace.create(effects, this::bodyStart, Types.linePrefix, Constants.tabSize),
+                                        this::tableClose))
                         .step(code);
             }
 
@@ -503,16 +509,16 @@ public class GfmTableSyntax extends Extension {
                 construct.partial = true;
 
                 return effects.check.hook(
-                        nextPrefixedOrBlank,
-                        this::tableBodyClose,
-                        effects.attempt.hook(
-                                construct,
-                                FactorySpace.create(
-                                        effects,
-                                        this::rowStartBody,
-                                        Types.linePrefix,
-                                        Constants.tabSize),
-                                this::tableBodyClose))
+                                nextPrefixedOrBlank,
+                                this::tableBodyClose,
+                                effects.attempt.hook(
+                                        construct,
+                                        FactorySpace.create(
+                                                effects,
+                                                this::rowStartBody,
+                                                Types.linePrefix,
+                                                Constants.tabSize),
+                                        this::tableBodyClose))
                         .step(code);
             }
 


### PR DESCRIPTION
### Summary

This PR performs an Extract Method refactoring in `GfmTableSyntax.StateMachine#atRowEndHead`.

It extracts `getState` from `atRowEndHead` to separate the following coherent subtask: closing the table header tokens and attempting to parse the delimiter row while temporarily enabling interrupt mode.

### Motivation

The original method contains multiple logical steps. The extracted code block performs a self-contained state transition, so moving it into a separate method makes the original method shorter and easier to follow.

### Scope of Change

- Extracted `getState` from `atRowEndHead`
- Preserved the existing parsing behavior

### Validation

I verified the change locally with:

```bash
./gradlew :markdown:test
```

The build completed successfully.
