### PR TITLE
Ignore item tooltip events fired off the render thread

### DIFF
--- a/src/main/java/guideme/internal/hotkey/OpenGuideHotkey.java
+++ b/src/main/java/guideme/internal/hotkey/OpenGuideHotkey.java
@@ -61,6 +61,15 @@ public final class OpenGuideHotkey {
                     if (evt.getEntity() != Minecraft.getInstance().player) {
                         return;
                     }
+                    // Also ignore any events not on the render thread. Vanilla's SessionSearchTrees
+                    // builds the creative-menu and recipe-book search trees on the background
+                    // executor and calls ItemStack#getTooltipLines with a null player there, and
+                    // EMI for example might try to index tooltips off-thread as well. The tooltip
+                    // this hotkey appends is measured with Font#width, which lazily bakes glyphs
+                    // into the font texture and therefore issues GL calls.
+                    if (!Minecraft.getInstance().isSameThread()) {
+                        return;
+                    }
                     handleTooltip(evt.getItemStack(), evt.getFlags(), evt.getToolTip());
                 });
         NeoForge.EVENT_BUS.addListener((ClientTickEvent.Post evt) -> newTick = true);


### PR DESCRIPTION
## What

Restores the off-thread guard in `OpenGuideHotkey`'s item-tooltip listener that was added in 59b53582ca (EMI indexing tooltips off-thread) but did not survive the port past 1.20.1.

## Why it matters again on 26.1

Vanilla itself is now an off-thread caller: `SessionSearchTrees` builds the creative-menu / recipe-book search trees on `Util.backgroundExecutor()` and calls `ItemStack#getTooltipLines` there with a **null** player — so the existing `evt.getEntity() != Minecraft.getInstance().player` filter passes (`null != null` → false) and the listener runs on a worker thread. Building the "Hold X to show guide" hint measures text via `Font#width`, which lazily bakes glyphs into the font texture and issues GL calls → `IllegalStateException: Rendersystem called from wrong thread`, reported as a `charTyped` crash. Typing in the creative search box is enough to reproduce with GuideME installed.

## Fix

Same 5-line shape as 59b53582ca: bail out of the listener when not on the render thread. Costs only the hotkey hint (a render-time affordance); off-thread search-tree tooltips don't need it. Also keeps `OpenGuideHotkey`'s static tick state confined to the client thread.

Found while running GuideME in a 26.1.2 modpack (crash log available on request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)