### PR TITLE
Add fallback for potentially missing items to ItemLink

### DIFF
--- a/docs/docs/30-authoring/index.md
+++ b/docs/docs/30-authoring/index.md
@@ -155,6 +155,9 @@ If the link targets an item from the same namespace as the page, an error will b
 You can opt out of this behavior by adding `optional={true}` or just `optional` to the link, or opt in for items of other mods by 
 adding `optional={false}`.
 
+If you're linking to items from another mod and want to account for cases where the item doesn't exist at all,
+you can specify a `fallback="text"` attribute to show a fallback text instead of an error.
+
 ### Command Links
 
 You can make links that run a command when clicked using `<CommandLink command="/command">text text</CommandLink>`.

--- a/src/main/java/guideme/compiler/tags/ItemLinkCompiler.java
+++ b/src/main/java/guideme/compiler/tags/ItemLinkCompiler.java
@@ -3,6 +3,7 @@ package guideme.compiler.tags;
 import guideme.compiler.PageCompiler;
 import guideme.document.flow.LytFlowLink;
 import guideme.document.flow.LytFlowParent;
+import guideme.document.flow.LytFlowSpan;
 import guideme.document.flow.LytTooltipSpan;
 import guideme.document.interaction.ItemTooltip;
 import guideme.indices.ItemIndex;
@@ -29,7 +30,7 @@ public class ItemLinkCompiler extends FlowTagCompiler {
         }
         if (itemAndId == null) {
             if (fallback != null) {
-                var span = new LytTooltipSpan();
+                var span = new LytFlowSpan();
                 span.modifyStyle(style -> style.italic(true));
                 span.appendText(fallback);
                 parent.append(span);

--- a/src/main/java/guideme/compiler/tags/ItemLinkCompiler.java
+++ b/src/main/java/guideme/compiler/tags/ItemLinkCompiler.java
@@ -8,6 +8,9 @@ import guideme.document.interaction.ItemTooltip;
 import guideme.indices.ItemIndex;
 import guideme.libs.mdast.mdx.model.MdxJsxElementFields;
 import java.util.Set;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.item.ItemStack;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class ItemLinkCompiler extends FlowTagCompiler {
     @Override
@@ -17,8 +20,20 @@ public class ItemLinkCompiler extends FlowTagCompiler {
 
     @Override
     public void compile(PageCompiler compiler, LytFlowParent parent, MdxJsxElementFields el) {
-        var itemAndId = MdxAttrs.getRequiredItemStackAndId(compiler, parent, el);
+        var fallback = MdxAttrs.getString(compiler, parent, el, "fallback", null);
+        Pair<Identifier, ItemStack> itemAndId;
+        if (fallback != null) {
+            itemAndId = MdxAttrs.getItemStackAndId(compiler, parent, el);
+        } else {
+            itemAndId = MdxAttrs.getRequiredItemStackAndId(compiler, parent, el);
+        }
         if (itemAndId == null) {
+            if (fallback != null) {
+                var span = new LytTooltipSpan();
+                span.modifyStyle(style -> style.italic(true));
+                span.appendText(fallback);
+                parent.append(span);
+            }
             return;
         }
         var id = itemAndId.getLeft();

--- a/src/main/java/guideme/compiler/tags/MdxAttrs.java
+++ b/src/main/java/guideme/compiler/tags/MdxAttrs.java
@@ -139,6 +139,15 @@ public final class MdxAttrs {
     }
 
     @Nullable
+    public static Pair<Identifier, Item> getItemAndId(PageCompiler compiler, LytErrorSink errorSink,
+            MdxJsxElementFields el, String attribute) {
+        var itemId = getRequiredId(compiler, errorSink, el, attribute);
+
+        var resultItem = BuiltInRegistries.ITEM.getOptional(itemId).orElse(null);
+        return resultItem == null ? null : Pair.of(itemId, resultItem);
+    }
+
+    @Nullable
     public static Pair<Identifier, EntityType<?>> getRequiredEntityTypeAndId(PageCompiler compiler,
             LytErrorSink errorSink,
             MdxJsxElementFields el,
@@ -175,10 +184,19 @@ public final class MdxAttrs {
             LytErrorSink errorSink,
             MdxJsxElementFields el) {
         var itemAndId = getRequiredItemAndId(compiler, errorSink, el, "id");
-        if (itemAndId == null) {
-            return null;
-        }
+        return itemAndId == null ? null : getItemStackAndId(compiler, errorSink, el, itemAndId);
+    }
 
+    @Nullable
+    public static Pair<Identifier, ItemStack> getItemStackAndId(PageCompiler compiler, LytErrorSink errorSink,
+            MdxJsxElementFields el) {
+        var itemAndId = getItemAndId(compiler, errorSink, el, "id");
+        return itemAndId == null ? null : getItemStackAndId(compiler, errorSink, el, itemAndId);
+    }
+
+    @Nullable
+    private static Pair<Identifier, ItemStack> getItemStackAndId(PageCompiler compiler, LytErrorSink errorSink,
+            MdxJsxElementFields el, Pair<Identifier, Item> itemAndId) {
         var stack = new ItemStack(itemAndId.getRight());
         var componentsString = MdxAttrs.getString(compiler, errorSink, el, "components", null);
         if (componentsString != null) {

--- a/src/testmod/resources/assets/testmod/guides/testmod/guide/index.md
+++ b/src/testmod/resources/assets/testmod/guides/testmod/guide/index.md
@@ -25,6 +25,8 @@ You may ~~need~~ a <Color color="#ff0000">door</Color> <Color id="test_color">do
 
 <ItemLink id="minecraft:stick" components="rarity=epic" />
 
+<ItemLink id="not_installed:doesnt_exist" fallback="Fallback for non-existent item" />
+
 <GameScene zoom={4} interactive={true}>
     <Entity id="minecraft:sheep" data="{Color: 2}" />
     <Block id="minecraft:water" />


### PR DESCRIPTION
This PR adds a fallback string attribute to `ItemLink` tags to allow linking to an item from another mod that is not required to be installed. This is useful in cases where a guide describes optional mod compat without having to hide the entire section through other means if the compat mod is not installed.