### PR TITLE
Add optional section dependent on the presence or absence of a mod

### DIFF
--- a/src/main/java/guideme/compiler/tags/OptionalSectionCompiler.java
+++ b/src/main/java/guideme/compiler/tags/OptionalSectionCompiler.java
@@ -1,0 +1,32 @@
+package guideme.compiler.tags;
+
+import guideme.compiler.PageCompiler;
+import guideme.document.block.LytBlockContainer;
+import guideme.libs.mdast.mdx.model.MdxJsxElementFields;
+import java.util.Set;
+import net.neoforged.fml.ModList;
+
+public class OptionalSectionCompiler extends BlockTagCompiler {
+    @Override
+    public Set<String> getTagNames() {
+        return Set.of("OptionalSection");
+    }
+
+    @Override
+    protected void compile(PageCompiler compiler, LytBlockContainer parent, MdxJsxElementFields el) {
+        var modId = MdxAttrs.getString(compiler, parent, el, "modId", null);
+        if (modId == null) {
+            parent.appendError(compiler, "Missing modId attribute.", el);
+            return;
+        }
+
+        boolean invert = false;
+        if (modId.startsWith("!")) {
+            modId = modId.substring(1);
+            invert = true;
+        }
+        if (ModList.get().isLoaded(modId) ^ invert) {
+            compiler.compileBlockContext(el.children(), parent);
+        }
+    }
+}

--- a/src/main/java/guideme/internal/extensions/DefaultExtensions.java
+++ b/src/main/java/guideme/internal/extensions/DefaultExtensions.java
@@ -13,6 +13,7 @@ import guideme.compiler.tags.FloatingImageCompiler;
 import guideme.compiler.tags.ItemGridCompiler;
 import guideme.compiler.tags.ItemLinkCompiler;
 import guideme.compiler.tags.KeyBindTagCompiler;
+import guideme.compiler.tags.OptionalSectionCompiler;
 import guideme.compiler.tags.PlayerNameTagCompiler;
 import guideme.compiler.tags.RecipeCompiler;
 import guideme.compiler.tags.RecipeTypeMappingSupplier;
@@ -85,7 +86,8 @@ public final class DefaultExtensions {
                 new SubPagesCompiler(),
                 new CommandLinkCompiler(),
                 new PlayerNameTagCompiler(),
-                new KeyBindTagCompiler());
+                new KeyBindTagCompiler(),
+                new OptionalSectionCompiler());
     }
 
     private static List<SceneElementTagCompiler> sceneElementTagCompilers() {

--- a/src/testmod/resources/assets/testmod/guides/testmod/guide/index.md
+++ b/src/testmod/resources/assets/testmod/guides/testmod/guide/index.md
@@ -82,3 +82,19 @@ You may ~~need~~ a <Color color="#ff0000">door</Color> <Color id="test_color">do
 </Row>
 
 <ItemImage id="minecraft:recovery_compass" />
+
+## Optional content
+
+<OptionalSection modId="not_installed">
+  This text must not be visible because no mod with ID `not_installed` is loaded!
+</OptionalSection>
+
+<OptionalSection modId="!guideme">
+  This text must not be visible because GuideME is loaded!
+</OptionalSection>
+
+<OptionalSection modId="minecraft">
+  This text is visible because Minecraft is loaded!
+</OptionalSection>
+
+End of optional content


### PR DESCRIPTION
This PR adds an `OptionalSection` block tag which allows the contained content to be conditionally rendered depending on the presence or absence of another mod. This is for example useful in cases where a guide describes optional mod compat and wants to hide the relevant paragraph(s) in the absence of the mod and/or hide a description of a fallback mechanism in the presence of the mod.
If preferred I can switch the inversion of the condition from a `!` prefix to an additional boolean attribute.